### PR TITLE
[Feature] Add less than, less than or equal, and equality comparison

### DIFF
--- a/gramaticas/kareljava.jison
+++ b/gramaticas/kareljava.jison
@@ -475,6 +475,24 @@ term
         dataType:"BOOL"
       };
     }
+  | term '<' term 
+    { 
+      $$ = {
+        left: $1, 
+        right: $3, 
+        operation: "LT", 
+        dataType:"BOOL"
+      };
+    }
+  | term '<=' term 
+    { 
+      $$ = {
+        left: $1, 
+        right: $3, 
+        operation: "LTE", 
+        dataType:"BOOL"
+      };
+    }
   | NOT term 
     { 
       $$ = {

--- a/gramaticas/kareljava.jison
+++ b/gramaticas/kareljava.jison
@@ -57,8 +57,8 @@
 "*"                             { return '*'; }
 ","                             { return ','; }
 "=="                            { return '=='; }
-"<"                             { return '<'; }
 "<="                            { return '<='; }
+"<"                             { return '<'; }
 [0-9]+                          { return 'NUM'; }
 [a-zA-Z][a-zA-Z0-9_]*           { return 'VAR'; }
 <<EOF>>                         { return 'EOF'; }

--- a/gramaticas/kareljava.jison
+++ b/gramaticas/kareljava.jison
@@ -56,6 +56,9 @@
 "."                             { return '.'; }
 "*"                             { return '*'; }
 ","                             { return ','; }
+"=="                            { return '=='; }
+"<"                             { return '<'; }
+"<="                            { return '<='; }
 [0-9]+                          { return 'NUM'; }
 [a-zA-Z][a-zA-Z0-9_]*           { return 'VAR'; }
 <<EOF>>                         { return 'EOF'; }
@@ -86,6 +89,8 @@ function resetCompiler(tag) {
 
 %left OR
 %left AND
+%nonassoc '=='
+%nonassoc '<' '<='
 %right NOT
 
 %%
@@ -458,6 +463,15 @@ term
         left: $1, 
         right: $3, 
         operation: "AND", 
+        dataType:"BOOL"
+      };
+    }
+  | term '==' term 
+    { 
+      $$ = {
+        left: $1, 
+        right: $3, 
+        operation: "EQ", 
         dataType:"BOOL"
       };
     }

--- a/gramaticas/karelpascal.jison
+++ b/gramaticas/karelpascal.jison
@@ -79,6 +79,9 @@
 "."                                         { return '.'; }
 ","                                         { return ','; }
 "*"                                         { return '*'; }
+"=="                                         { return '=='; }
+"<"                                         { return '<'; }
+"<="                                         { return '<='; }
 [0-9]+                                      { return 'NUM'; }
 [A-Za-zÀ-ÖØ-öø-ÿ_][A-Za-zÀ-ÖØ-öø-ÿ0-9_-]*   { return 'VAR'; }
 <<EOF>>                                     { return 'EOF'; }
@@ -109,6 +112,8 @@ function resetCompiler(tag) {
 
 %left OR
 %left AND
+%nonassoc '=='
+%nonassoc '<' '<='
 %right NOT
 
 
@@ -503,6 +508,15 @@ term
         left: $1, 
         right: $3, 
         operation: "AND", 
+        dataType:"BOOL"
+      };
+    }
+  | term '==' term 
+    { 
+      $$ = {
+        left: $1, 
+        right: $3, 
+        operation: "EQ", 
         dataType:"BOOL"
       };
     }

--- a/gramaticas/karelpascal.jison
+++ b/gramaticas/karelpascal.jison
@@ -79,9 +79,9 @@
 "."                                         { return '.'; }
 ","                                         { return ','; }
 "*"                                         { return '*'; }
-"=="                                         { return '=='; }
+"=="                                        { return '=='; }
+"<="                                        { return '<='; }
 "<"                                         { return '<'; }
-"<="                                         { return '<='; }
 [0-9]+                                      { return 'NUM'; }
 [A-Za-zÀ-ÖØ-öø-ÿ_][A-Za-zÀ-ÖØ-öø-ÿ0-9_-]*   { return 'VAR'; }
 <<EOF>>                                     { return 'EOF'; }

--- a/gramaticas/karelpascal.jison
+++ b/gramaticas/karelpascal.jison
@@ -520,6 +520,24 @@ term
         dataType:"BOOL"
       };
     }
+  | term '<' term 
+    { 
+      $$ = {
+        left: $1, 
+        right: $3, 
+        operation: "LT", 
+        dataType:"BOOL"
+      };
+    }
+  | term '<=' term 
+    { 
+      $$ = {
+        left: $1, 
+        right: $3, 
+        operation: "LTE", 
+        dataType:"BOOL"
+      };
+    }
   | NOT term 
     { 
       $$ = {

--- a/src/__tests__/runtime.test.ts
+++ b/src/__tests__/runtime.test.ts
@@ -51,4 +51,118 @@ describe("Test runtime", () => {
         expect(runtime.state.stack[0]).toBe(1);
         expect(runtime.state.stack[1]).toBe(12);    
     });
+    
+    test("Test LT", () => {
+        const world = new World(10,10)
+        const runtime = new Runtime(world);
+        world.runtime = runtime;
+        runtime.load([
+            ["LOAD", 2],
+            ["LOAD", 5],
+            ["LT"],
+
+            ["POP"],            
+            ["LOAD", 5],
+            ["LOAD", 2],
+            ["LT"],
+
+            ["POP"],            
+            ["LOAD", 5],
+            ["LOAD", 5],
+            ["LT"],
+            
+        ]);
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();  
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();  
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();  
+        expect(runtime.state.stack[0]).toBe(1);
+        expect(runtime.state.sp).toBe(0);
+
+        
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();
+          
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();  
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();  
+        runtime.next();
+        expect(runtime.state.stack[0]).toBe(0);
+        expect(runtime.state.sp).toBe(0);
+        
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();
+          
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();  
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();  
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();  
+        expect(runtime.state.stack[0]).toBe(0);
+        expect(runtime.state.sp).toBe(0);
+        
+        expect(runtime.state.error).toBeUndefined();  
+    });
+
+    
+    
+    test("Test LTE",() => {
+        const world = new World(10,10)
+        const runtime = new Runtime(world);
+        world.runtime = runtime;
+        runtime.load([
+            ["LOAD", 2],
+            ["LOAD", 5],
+            ["LTE"],
+
+            ["POP"],            
+            ["LOAD", 5],
+            ["LOAD", 2],
+            ["LTE"],
+
+            ["POP"],            
+            ["LOAD", 5],
+            ["LOAD", 5],
+            ["LTE"],
+            
+        ]);
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();  
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();  
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();  
+        expect(runtime.state.stack[0]).toBe(1);
+        expect(runtime.state.sp).toBe(0);
+
+        
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();
+          
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();  
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();  
+        runtime.next();
+        expect(runtime.state.stack[0]).toBe(0);
+        expect(runtime.state.sp).toBe(0);
+        
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();
+          
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();  
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();  
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined();  
+        expect(runtime.state.stack[0]).toBe(1);
+        expect(runtime.state.sp).toBe(0);
+        
+        expect(runtime.state.error).toBeUndefined();  
+    });
 });

--- a/src/compiler/InterRep/AstExpression.ts
+++ b/src/compiler/InterRep/AstExpression.ts
@@ -52,6 +52,26 @@ function resolveTerm(tree: IRTerm, definitions: DefinitionTable, parameters: IRP
         target.push([tree.operation]);
         return tree.dataType;
     }
+
+    
+
+    if (tree.operation === "LT" || tree.operation === "LTE") {
+        const leftType = resolveTerm(tree.left, definitions, parameters, expectedReturn, target, tags, yy);
+        const rightType = resolveTerm(tree.right, definitions, parameters, expectedReturn, target, tags, yy);
+        if (leftType !== "INT") {
+            yy.parser.parseError(`${tree.operation} operator uses integer terms only, left is of type: ${leftType}`, {
+                //FIXME: Add data (?)
+            });
+        }
+        if (rightType !== "INT") {
+            yy.parser.parseError(`${tree.operation} operator uses integer terms only, right is of type: ${rightType}`, {
+                //FIXME: Add data (?)
+            });
+        }
+        target.push([tree.operation]);
+        return tree.dataType;
+    }
+
     if (tree.operation === "NOT") {
         const termType = resolveTerm(tree.term, definitions, parameters, expectedReturn, target, tags, yy);
         if (termType !== "BOOL") {

--- a/src/compiler/InterRep/AstExpression.ts
+++ b/src/compiler/InterRep/AstExpression.ts
@@ -40,6 +40,18 @@ function resolveTerm(tree: IRTerm, definitions: DefinitionTable, parameters: IRP
         target.push([tree.operation]);
         return tree.dataType;
     }
+    
+    if (tree.operation === "EQ") {
+        const leftType = resolveTerm(tree.left, definitions, parameters, expectedReturn, target, tags, yy);
+        const rightType = resolveTerm(tree.right, definitions, parameters, expectedReturn, target, tags, yy);
+        if (leftType !== rightType) {
+            yy.parser.parseError(`An equality comparison cannot be performed between type ${leftType} and ${rightType}`, {
+                //FIXME: Add data (?)
+            });
+        }
+        target.push([tree.operation]);
+        return tree.dataType;
+    }
     if (tree.operation === "NOT") {
         const termType = resolveTerm(tree.term, definitions, parameters, expectedReturn, target, tags, yy);
         if (termType !== "BOOL") {

--- a/src/compiler/InterRep/IRInstruction.ts
+++ b/src/compiler/InterRep/IRInstruction.ts
@@ -44,7 +44,7 @@ export type IRFunction = {
  */
 export type IRTerm = 
     {
-        operation: "AND" | "OR" | "EQ",
+        operation: "AND" | "OR" | "EQ" | "LT" | "LTE",
         left: IRTerm,
         right: IRTerm,
         dataType: "BOOL"
@@ -106,7 +106,9 @@ export type IRInstruction =
     [instruction: "RET", "__DEFAULT", loc:YYLoc] |
     [instruction: "PARAM", index: number] |
     [instruction: "SRET"] |
-    [instruction: "LRET"] |
+    [instruction: "LRET"] | 
+    [instruction: "LT"]  |
+    [instruction: "LTE"] |
     //These ones are a IR only instructions, they must be resolved to a correct opcode
     [instruction: "VAR", data:IRVar] |
     [instruction: "TERM", data:IRTerm] | //Represents a term like a || b || !(x)

--- a/src/compiler/InterRep/IRInstruction.ts
+++ b/src/compiler/InterRep/IRInstruction.ts
@@ -44,7 +44,7 @@ export type IRFunction = {
  */
 export type IRTerm = 
     {
-        operation: "AND" | "OR",
+        operation: "AND" | "OR" | "EQ",
         left: IRTerm,
         right: IRTerm,
         dataType: "BOOL"

--- a/src/compiler/opcodes.ts
+++ b/src/compiler/opcodes.ts
@@ -31,6 +31,8 @@ export enum OpCodeID {
   PARAM,
   SRET,
   LRET,
+  LT,
+  LTE
 };
 
 export type OpCodeLiteral = keyof typeof OpCodeID
@@ -87,7 +89,9 @@ export type OpCode =
   [instruction: "RET"] |
   [instruction: "PARAM", index: number] |
   [instruction: "SRET"] |
-  [instruction: "LRET"] 
+  [instruction: "LRET"] | 
+  [instruction: "LT"]  |
+  [instruction: "LTE"] 
   ;
 
 export type RawProgram = OpCode[]

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -491,6 +491,20 @@ export class Runtime {
           break;
         }
 
+        case OpCodeID.LT: {
+          op2 = this.state.stack[this.state.sp--];
+          op1 = this.state.stack[this.state.sp--];
+          this.state.stack[++this.state.sp] = op1 < op2 ? 1 : 0;
+          break;
+        }
+
+        case OpCodeID.LTE: {          
+          op2 = this.state.stack[this.state.sp--];
+          op1 = this.state.stack[this.state.sp--];
+          this.state.stack[++this.state.sp] = op1 <= op2 ? 1 : 0;
+          break;
+        }
+
         default: {
           this.state.running = false;
           if (this.debug) {


### PR DESCRIPTION
Fixes https://github.com/kishtarn555/rekarel-core/issues/20

`<` `<=` and `==` in both languages

`<` and `<=` can only operate between integers

`==` can only operate between two terms of the same type