### PR TITLE
[Feature] In non-void functions, return a compilation error if there's no explicit return

### DIFF
--- a/src/__tests__/java.test.ts
+++ b/src/__tests__/java.test.ts
@@ -21,6 +21,8 @@ const compilationError:[string,string | RegExp][] = [
     ["returnIntToVoid.kj", "Cannot return a type: INT, in a function of type: VOID"],
     ["voidAsInt.kj", "Expected a term of type INT, but got VOID"],
     ["emptyReturn.kj", "Explicit return is required in function pasos"],
+    ["halfTrueReturn.kj", "Explicit return is required in function pasos"],
+    ["halfFalseReturn.kj", "Explicit return is required in function pasos"],
 ]
 
 

--- a/src/__tests__/java.test.ts
+++ b/src/__tests__/java.test.ts
@@ -11,7 +11,8 @@ const sourceFiles = [
     "globals.not.kj",
     "testInc.kj",
     "testDec.kj",
-    "intfunc.kj"
+    "intfunc.kj",
+    "ifReturn.kj"
 ]
 
 
@@ -19,6 +20,7 @@ const compilationError:[string,string | RegExp][] = [
     ["returnVoidToInt.kj", "Cannot return a type: VOID, in a function of type: INT"],
     ["returnIntToVoid.kj", "Cannot return a type: INT, in a function of type: VOID"],
     ["voidAsInt.kj", "Expected a term of type INT, but got VOID"],
+    ["emptyReturn.kj", "Explicit return is required in function pasos"],
 ]
 
 

--- a/src/__tests__/kj/ce/emptyReturn.kj
+++ b/src/__tests__/kj/ce/emptyReturn.kj
@@ -1,0 +1,8 @@
+class program {
+    int pasos() {
+        move();
+    }
+    program() {
+        pasos();
+    }
+}

--- a/src/__tests__/kj/ce/halfFalseReturn.kj
+++ b/src/__tests__/kj/ce/halfFalseReturn.kj
@@ -1,0 +1,13 @@
+class program {
+    int pasos() {
+        if (frontIsClear) {
+            move();
+        } else {
+            turnleft();
+            return 5;
+        }
+    }
+    program() {
+        pasos();
+    }
+}

--- a/src/__tests__/kj/ce/halfTrueReturn.kj
+++ b/src/__tests__/kj/ce/halfTrueReturn.kj
@@ -1,0 +1,13 @@
+class program {
+    int pasos() {
+        if (frontIsClear) {
+            move();
+            return 5;
+        } else {
+            turnleft();
+        }
+    }
+    program() {
+        pasos();
+    }
+}

--- a/src/__tests__/kj/ifReturn.kj
+++ b/src/__tests__/kj/ifReturn.kj
@@ -1,0 +1,13 @@
+class program {
+    int pasos() {
+        if (frontIsClear) {
+            move();
+            return 5;
+        } else {
+            return 0;
+        }
+    }
+    program() {
+        pasos();
+    }
+}

--- a/src/__tests__/kp/ce/emptyReturn.kp
+++ b/src/__tests__/kp/ce/emptyReturn.kp
@@ -1,0 +1,10 @@
+iniciar-programa
+	define-instruccion-entera pasos como
+	inicio
+		avanza;
+	fin;
+
+	inicia-ejecucion
+		pasos;
+	termina-ejecucion
+finalizar-programa

--- a/src/__tests__/kp/ce/halfFalseReturn.kp
+++ b/src/__tests__/kp/ce/halfFalseReturn.kp
@@ -1,0 +1,19 @@
+iniciar-programa
+	define-instruccion-entera pasos como
+	inicio
+        si frente-libre entonces
+        inicio
+		    avanza;
+        fin
+        sino
+        inicio
+            gira-izquierda;
+            regresa 5;
+        fin;
+
+	fin;
+
+	inicia-ejecucion
+		pasos;
+	termina-ejecucion
+finalizar-programa

--- a/src/__tests__/kp/ce/halfTrueReturn.kp
+++ b/src/__tests__/kp/ce/halfTrueReturn.kp
@@ -1,0 +1,19 @@
+iniciar-programa
+	define-instruccion-entera pasos como
+	inicio
+        si frente-libre entonces
+        inicio
+		    avanza;
+            regresa 5;
+        fin
+        sino
+        inicio
+            gira-izquierda;
+        fin;
+
+	fin;
+
+	inicia-ejecucion
+		pasos;
+	termina-ejecucion
+finalizar-programa

--- a/src/__tests__/kp/ifReturn.kp
+++ b/src/__tests__/kp/ifReturn.kp
@@ -1,0 +1,19 @@
+iniciar-programa
+	define-instruccion-entera pasos como
+	inicio
+        si frente-libre entonces
+        inicio
+		    avanza;
+            regresa 5;
+        fin
+        sino
+        inicio
+            regresa 0;
+        fin;
+
+	fin;
+
+	inicia-ejecucion
+		pasos;
+	termina-ejecucion
+finalizar-programa

--- a/src/__tests__/pascal.test.ts
+++ b/src/__tests__/pascal.test.ts
@@ -23,6 +23,8 @@ const compilationError:[string,string | RegExp][] = [
     ["returnIntToVoid.kp", "Cannot return a type: INT, in a function of type: VOID"],
     ["voidAsInt.kp", "Expected a term of type INT, but got VOID"],
     ["emptyReturn.kp", "Explicit return is required in function pasos"],
+    ["halfTrueReturn.kp", "Explicit return is required in function pasos"],
+    ["halfFalseReturn.kp", "Explicit return is required in function pasos"],
 ]
 
 

--- a/src/__tests__/pascal.test.ts
+++ b/src/__tests__/pascal.test.ts
@@ -14,6 +14,7 @@ const sourceFiles = [
     "globals.not.kp",
     "testInc.kp", 
     "testDec.kp",
+    "ifReturn.kp"
 ]
 
 
@@ -21,11 +22,12 @@ const compilationError:[string,string | RegExp][] = [
     ["returnVoidToInt.kp", "Cannot return a type: VOID, in a function of type: INT"],
     ["returnIntToVoid.kp", "Cannot return a type: INT, in a function of type: VOID"],
     ["voidAsInt.kp", "Expected a term of type INT, but got VOID"],
+    ["emptyReturn.kp", "Explicit return is required in function pasos"],
 ]
 
 
 
-describe("Pascal compilation tests ", () => {
+describe("Pascal compilation tests ", () => { 
     test("Test simple turnoff", () => {
         const source = fs.readFileSync(__dirname + "/kp/turnoff.kp").toString();
         const result = compile(source);
@@ -81,6 +83,18 @@ describe("Test Pascal compilation errors" ,  ()=> {
         });
     }
 });
+
+
+describe("Test Pascal compilations", ()=> {
+    for (const file of sourceFiles) {
+        test(`Test compilation of ${file}`, ()=> {            
+            const source = fs.readFileSync(__dirname +"/kp/"+file).toString();
+            const result = compile (source);
+            expect(Array.isArray(result)).toBe(true);            
+            
+        });
+    }
+})
 
 describe("Pascal globals test ", () => {
     test("Test floor variable", () => {


### PR DESCRIPTION
This gives a compilation error:
```java
int pasos() {
  move();
}
```


This compiles
```java
int pasos() {
  if (frontIsClear) {
    move();
    return 5;
  } else {
    return 0;
  }
}
```

Fixes https://github.com/kishtarn555/rekarel-core/issues/38
