### PR TITLE
[Fix] Parameter missmatch between a call and its definition gave an internal error

### DIFF
--- a/gramaticas/karelpascal.jison
+++ b/gramaticas/karelpascal.jison
@@ -415,7 +415,9 @@ int_termList
         {
           term:$term, 
           operation: 'PASS',
-          dataType: 'INT'
+          dataType: 'INT',
+          loc: @term,
+          totalLoc: @term
         } 
       ])
     }
@@ -425,7 +427,9 @@ int_termList
         {
           term:$term, 
           operation: 'PASS',
-          dataType: 'INT'
+          dataType: 'INT',
+          loc: @term,
+          totalLoc: @term
         } 
       ]; 
     }
@@ -505,7 +509,9 @@ term
         left: $1, 
         right: $3, 
         operation: "OR", 
-        dataType:"BOOL" 
+        dataType:"BOOL",
+        loc: @2,
+        totalLoc: @$ 
       }; }
   | term AND term 
     { 
@@ -513,7 +519,9 @@ term
         left: $1, 
         right: $3, 
         operation: "AND", 
-        dataType:"BOOL"
+        dataType:"BOOL",
+        loc: @2,
+        totalLoc: @$
       };
     }
   | term '==' term 
@@ -522,7 +530,9 @@ term
         left: $1, 
         right: $3, 
         operation: "EQ", 
-        dataType:"BOOL"
+        dataType:"BOOL",
+        loc: @2,
+        totalLoc: @$
       };
     }
   | term '<' term 
@@ -531,7 +541,9 @@ term
         left: $1, 
         right: $3, 
         operation: "LT", 
-        dataType:"BOOL"
+        dataType:"BOOL",
+        loc: @2,
+        totalLoc: @$
       };
     }
   | term '<=' term 
@@ -540,7 +552,9 @@ term
         left: $1, 
         right: $3, 
         operation: "LTE", 
-        dataType:"BOOL"
+        dataType:"BOOL",
+        loc: @2,
+        totalLoc: @$
       };
     }
   | NOT term 
@@ -548,7 +562,9 @@ term
       $$ = {
         term: $2,       
         operation: "NOT",
-        dataType:"BOOL" 
+        dataType:"BOOL" ,
+        loc: @1,
+        totalLoc: @$
       };
       }
   | '(' term ')'
@@ -565,7 +581,9 @@ bool_term
         {
           term:$term, 
           operation: 'PASS',
-          dataType: 'BOOL'
+          dataType: 'BOOL',
+          loc: @term,
+          totalLoc: @term
         }    
       ]];
     }
@@ -580,7 +598,9 @@ int_term
         {
           term:$term, 
           operation: 'PASS',
-          dataType: 'INT'
+          dataType: 'INT',
+          loc: @term,
+          totalLoc: @term
         }    
       ]];
     }
@@ -592,7 +612,9 @@ clause
        $$ = {
         operation: "ATOM",
         instructions: $int_term.concat([['NOT']]),
-        dataType: "BOOL"
+        dataType: "BOOL",
+        loc: @1,
+        totalLoc: @$
       };
     }
   | bool_fun
@@ -600,7 +622,9 @@ clause
       $$ = {
         operation: "ATOM",
         instructions: $bool_fun,
-        dataType: "BOOL"
+        dataType: "BOOL",
+        loc: @1,
+        totalLoc: @1
       }; 
     }
   | integer 
@@ -608,7 +632,9 @@ clause
       $$ = {
         operation: "ATOM",
         instructions: $integer,
-        dataType: "INT"
+        dataType: "INT",
+        loc: @1,
+        totalLoc: @1
       }; 
       
     }
@@ -626,7 +652,9 @@ clause
         $$ = {
           operation: "ATOM",
           instructions: ir,
-          dataType: "$"+$var.toLowerCase()
+          dataType: "$"+$var.toLowerCase(),
+          loc: @1,
+          totalLoc: @1
         }; 
       %}
   | parameteredCall 
@@ -636,7 +664,9 @@ clause
       $$ = {
         operation: "ATOM",
         instructions: [...callIR, ['LRET']],
-        dataType: "$"+callData.target
+        dataType: "$"+callData.target,
+        loc: @1,
+        totalLoc: @1
       }
     %}
   ;

--- a/src/compiler/InterRep/AstExpression.ts
+++ b/src/compiler/InterRep/AstExpression.ts
@@ -126,7 +126,6 @@ function resolveVar(data: IRVar, definitions: DefinitionTable, scope:Scope, targ
             "CALL",
             {
                 target: data.target,
-                argLoc: data.loc,
                 nameLoc: data.loc,
                 expectedType: data.expectedType,
                 params: [],

--- a/src/compiler/InterRep/IRInstruction.ts
+++ b/src/compiler/InterRep/IRInstruction.ts
@@ -7,7 +7,6 @@ import { YYLoc } from "./IRParserTypes";
 export type IRCall = {
     target: string,
     nameLoc: YYLoc,
-    argLoc: YYLoc,
     params: IRTerm[],
     expectedType?: string
 };

--- a/src/compiler/InterRep/IRInstruction.ts
+++ b/src/compiler/InterRep/IRInstruction.ts
@@ -47,22 +47,30 @@ export type IRTerm =
         operation: "AND" | "OR" | "EQ" | "LT" | "LTE",
         left: IRTerm,
         right: IRTerm,
-        dataType: "BOOL"
+        dataType: "BOOL",
+        loc: YYLoc,
+        totalLoc: YYLoc,
     } 
     | {
         operation: "NOT",
         term: IRTerm,
-        dataType: "BOOL"
+        dataType: "BOOL",
+        loc: YYLoc,
+        totalLoc: YYLoc,
     } 
     | {
         operation: "ATOM",
         instructions: IRInstruction[],
-        dataType: string
+        dataType: string,
+        loc: YYLoc,
+        totalLoc: YYLoc,
     }
     | {
         operation: "PASS",
         term: IRTerm,
-        dataType: string
+        dataType: string,
+        loc: YYLoc,
+        totalLoc: YYLoc,
     }
 ;
 

--- a/src/compiler/InterRep/IRProcessor.ts
+++ b/src/compiler/InterRep/IRProcessor.ts
@@ -252,21 +252,35 @@ export function generateOpcodesFromIR(data: IRObject): RawProgram {
                 return null;
             }
             const targetFunc = definitions.getFunction(iData.target);
-            if (targetFunc.arguments.length != iData.params.length) {
+            if (targetFunc.arguments.length < iData.params.length) {
+                const extraParam = iData.params[iData.params.length - targetFunc.arguments.length - 1];
                 data.yy.parser.parseError(
-                    `Function parameter mismatch on function ${iData.target}, expected ${targetFunc.arguments.length}, got ${iData.params.length}`, 
+                    `Too many parameters in call to function ${iData.target}, expected ${targetFunc.arguments.length}, got ${iData.params.length}`, 
                     {
                         text: iData.target,
-                        line: iData.argLoc.first_line - 1,
-                        loc: iData.argLoc,
-                        parameters: iData.argLoc, //Fixme: add Parameter IR location
+                        line: extraParam.totalLoc.first_line - 1,
+                        loc: extraParam.totalLoc,
+                        expectedCount: iData.params.length,
+                        gotCount: targetFunc.arguments.length
+                    }
+                );
+            }
+            if (targetFunc.arguments.length > iData.params.length) {
+                data.yy.parser.parseError(
+                    `Too few parameters in call to function ${iData.target}, expected ${targetFunc.arguments.length}, got ${iData.params.length}`, 
+                    {
+                        text: iData.target,
+                        line: iData.nameLoc.first_line - 1,
+                        loc: iData.nameLoc,
+                        expectedCount: iData.params.length,
+                        gotCount: targetFunc.arguments.length
                     }
                 );
             }
             if (iData.expectedType != null && iData.expectedType !== targetFunc.returnType) {
                 data.yy.parser.parseError(`Expected a function of type ${iData.expectedType}, but ${iData.target} is ${targetFunc.returnType}`, {
                     text: iData.target,
-                    line: iData.argLoc.first_line - 1,
+                    line: iData.nameLoc.first_line - 1,
                     loc: iData.nameLoc,
                     expectedType: iData.expectedType,
                     actualType: targetFunc.returnType


### PR DESCRIPTION
Now it returns errors such as

`Too few parameters in call to function pared, expected 2, got 1`


`Too many parameters in call to function pared, expected 2, got 3`