### PR TITLE
[Bug] Duplicate params in a function did not gave a compilation error

### DIFF
--- a/src/compiler/InterRep/IRProcessor.ts
+++ b/src/compiler/InterRep/IRProcessor.ts
@@ -164,6 +164,22 @@ function validateAndGetFunctionDefinitions(data: IRObject, definitionTable: Defi
         }
 
     }
+
+    //Validate parameters
+    for (const func of data.functions) {
+        func.params.forEach((param, idx) => {
+            if( definitionTable.hasVar(param.name) || definitionTable.hasFunction(param.name)) {
+                yy.parser.parseError(`Cannot name parameter ${param.name} as it is already used by a variable or function`, {
+                    error: CompilationError.Errors.PARAMETER_ILLEGAL_NAME,
+                    line: param.loc.first_line - 1,
+                    loc: param.loc,
+                    parameterName: param.name
+                });
+            }
+
+        });
+    }
+
     return true;
 }
 

--- a/src/compiler/InterRep/IRProcessor.ts
+++ b/src/compiler/InterRep/IRProcessor.ts
@@ -176,6 +176,15 @@ function validateAndGetFunctionDefinitions(data: IRObject, definitionTable: Defi
                     parameterName: param.name
                 });
             }
+            const first = func.params.findIndex(p => p.name === param.name);
+            if (first !== idx) {
+                yy.parser.parseError(`Parameter ${param.name} was already declared in the function`, {
+                    error: CompilationError.Errors.PARAMETER_REDEFINITION,
+                    line: param.loc.first_line - 1,
+                    loc: param.loc,
+                    parameterName: param.name
+                }); 
+            }
 
         });
     }

--- a/src/compiler/InterRep/compileErrors.ts
+++ b/src/compiler/InterRep/compileErrors.ts
@@ -11,6 +11,7 @@ export namespace CompilationError {
         ILLEGAL_CONTINUE,
         NO_EXPLICIT_RETURN,
         PARAMETER_ILLEGAL_NAME,
+        PARAMETER_REDEFINITION,
         PROTOTYPE_PARAMETERS_MISS_MATCH,
         PROTOTYPE_TYPE_MISS_MATCH,
         PROTOTYPE_REDEFINITION,
@@ -96,6 +97,12 @@ export namespace CompilationError {
         parameterName: string
     }
     
+    type ParameterRedefinitionErrorStatus = {
+        error: Errors.PARAMETER_REDEFINITION,
+        loc: YYLoc,
+        line: number,
+        parameterName: string
+    }
     type PrototypeParametersMissMatchRedefinitionErrorStatus = {
         error: Errors.PROTOTYPE_PARAMETERS_MISS_MATCH,
         loc: YYLoc,
@@ -223,6 +230,7 @@ export namespace CompilationError {
         | IllegalContinueErrorStatus
         | IllegalParameterNameErrorStatus
         | NoExplicitReturnErrorStatus
+        | ParameterRedefinitionErrorStatus
         | PrototypeRedefinitionErrorStatus
         | PrototypeParametersMissMatchRedefinitionErrorStatus
         | PrototypeTypeMissMatchRedefinitionErrorStatus


### PR DESCRIPTION
This is no longer allowed
```java
void f1 (b, b) 
```
Fixes #89 




