### PR TITLE
[Bug] First loads the term and then adds a line instruction for the return

### DIFF
--- a/gramaticas/kareljava.jison
+++ b/gramaticas/kareljava.jison
@@ -320,19 +320,19 @@ expr
 return
   : RET '(' ')'
     { $$ = [
-      locToIR(@1),
       ['RET', {
         term: { operation: "ATOM", instructions:[["LOAD", 0]], dataType:"VOID" },
         loc: @1
-      }]
+      }],
+      locToIR(@1)
     ]; }
   | RET 
     { $$ = [
-      locToIR(@1),
       ['RET', {
         term: { operation: "ATOM", instructions:[["LOAD", 0]], dataType:"VOID" },
         loc: @1
-      }]
+      }],      
+      locToIR(@1)
     ]; }
   | RET  term 
     

--- a/gramaticas/karelpascal.jison
+++ b/gramaticas/karelpascal.jison
@@ -371,20 +371,20 @@ return
   : RET 
     
     { $$ = [
-      locToIR(@1),
       ['RET', {
         term: { operation: "ATOM", instructions:[["LOAD", 0]], dataType:"VOID" },
         loc: @1
-      }]
+      }],
+      locToIR(@1)
     ]; }
   | RET term
     
     { $$ = [
-      locToIR(@1),
       ['RET', {
         term: $term,
         loc: @1
-      }]
+      }],
+      locToIR(@1)
     ]; }
   ;
 


### PR DESCRIPTION
return term

before was:

line -> term

Now it is
term -> line

Fixes #91 