### PR TITLE
[Feature] Boolean comparators now use short circuit evaluation

### DIFF
--- a/src/__tests__/java.test.ts
+++ b/src/__tests__/java.test.ts
@@ -173,3 +173,23 @@ describe("Test Java functions", ()=>{
         expect(world.buzzers(3, 1)).toBe(3);
     });
 });
+
+test("Java short circuit", ()=> {
+    const src = fs.readFileSync(__dirname + "/kj/shortCircuit.kj").toString();
+    const opcodes = compile(src);
+    expect(opcodes).toBeDefined()
+    const world = new World(10, 10);
+    world.setBagBuzzers(-1);
+    runAll(world, opcodes!);
+    expect(world.runtime.state.error).toBeUndefined();
+    //Test and shorting
+    expect(world.buzzers(1, 1)).toBe(6);
+    expect(world.buzzers(2, 1)).toBe(3);
+    expect(world.buzzers(3, 1)).toBe(2);
+    expect(world.buzzers(4, 1)).toBe(2);
+    //Test or shorting
+    expect(world.buzzers(5, 1)).toBe(5);
+    expect(world.buzzers(6, 1)).toBe(5);
+    expect(world.buzzers(7, 1)).toBe(7);
+    expect(world.buzzers(8, 1)).toBe(4);
+});

--- a/src/__tests__/kj/shortCircuit.kj
+++ b/src/__tests__/kj/shortCircuit.kj
@@ -1,0 +1,49 @@
+import rekarel.globals;
+class program {
+    bool always() {
+        putbeeper();
+        return true;
+    }
+    bool never() {
+        putbeeper();
+        putbeeper();
+        return true;
+    }
+    program() {
+        if (always() && always()) {
+            iterate(4) putbeeper();
+        }
+        move();
+        if (always() && never()) {
+            iterate(4) putbeeper();
+        }        
+        move();
+        if (never() && always()) {
+            iterate(4) putbeeper();
+        }
+        move();
+        if (never() && never()) {
+            iterate(4) putbeeper();
+        }
+        move();
+        // Or
+        
+        if (always() || always()) {
+            iterate(4) putbeeper();
+        }
+        move();
+        if (always() || never()) {
+            iterate(4) putbeeper();
+        }        
+        move();
+        if (never() || always()) {
+            iterate(4) putbeeper();
+        }
+        move();
+        if (never() || never()) {
+            iterate(4) putbeeper();
+        }
+
+    }
+
+}

--- a/src/__tests__/kj/shortCircuit.kj
+++ b/src/__tests__/kj/shortCircuit.kj
@@ -7,7 +7,7 @@ class program {
     bool never() {
         putbeeper();
         putbeeper();
-        return true;
+        return false;
     }
     program() {
         if (always() && always()) {

--- a/src/__tests__/kp/shortCircuit.kp
+++ b/src/__tests__/kp/shortCircuit.kp
@@ -1,0 +1,58 @@
+usa rekarel.globales;
+iniciar-programa
+    define-instruccion-booleana always como 
+    inicio
+        deja-zumbador;
+        regresa verdadero;
+    fin;
+
+    define-instruccion-booleana never como
+    inicio
+        deja-zumbador;
+        deja-zumbador;
+        regresa falso;
+    fin;
+
+    inicia-ejecucion
+        si always y always entonces
+            repetir 4 veces
+                deja-zumbador;
+        
+        avanza;
+        si always y never entonces
+            repetir 4 veces
+                deja-zumbador;
+                
+        avanza;
+        si never y always entonces
+            repetir 4 veces
+                deja-zumbador;
+        
+        avanza;
+        si never y never entonces
+            repetir 4 veces
+                deja-zumbador;
+        
+        avanza;
+        { O }
+        
+        si always o always entonces
+            repetir 4 veces
+                deja-zumbador;
+        
+        avanza;
+        si always o never entonces
+            repetir 4 veces
+                deja-zumbador;
+                
+        avanza;
+        si never o always entonces
+            repetir 4 veces
+                deja-zumbador;
+        
+        avanza;
+        si never o never entonces
+            repetir 4 veces
+                deja-zumbador;
+	termina-ejecucion
+finalizar-programa

--- a/src/__tests__/pascal.test.ts
+++ b/src/__tests__/pascal.test.ts
@@ -175,3 +175,24 @@ describe("Test Pascal functions", ()=>{
         expect(world.buzzers(3, 1)).toBe(3);
     });
 });
+
+
+test("Pascal short circuit", ()=> {
+    const src = fs.readFileSync(__dirname + "/kp/shortCircuit.kp").toString();
+    const opcodes = compile(src);
+    expect(opcodes).toBeDefined()
+    const world = new World(10, 10);
+    world.setBagBuzzers(-1);
+    runAll(world, opcodes!);
+    expect(world.runtime.state.error).toBeUndefined();
+    //Test and shorting
+    expect(world.buzzers(1, 1)).toBe(6);
+    expect(world.buzzers(2, 1)).toBe(3);
+    expect(world.buzzers(3, 1)).toBe(2);
+    expect(world.buzzers(4, 1)).toBe(2);
+    //Test or shorting
+    expect(world.buzzers(5, 1)).toBe(5);
+    expect(world.buzzers(6, 1)).toBe(5);
+    expect(world.buzzers(7, 1)).toBe(7);
+    expect(world.buzzers(8, 1)).toBe(4);
+});

--- a/src/compiler/InterRep/IRVarTable.ts
+++ b/src/compiler/InterRep/IRVarTable.ts
@@ -21,11 +21,13 @@ export class DefinitionTable {
     private functions: FunctionTable
     private variables: VariableTable
     private variablesCanBeFunctions: boolean
+    private tagCounter: number
 
     constructor(variablesCanBeFunctions: boolean) {
         this.functions = new Map();
         this.variables = new Map();
         this.variablesCanBeFunctions = variablesCanBeFunctions;
+        this.tagCounter = 0;
     }
 
 
@@ -71,6 +73,10 @@ export class DefinitionTable {
 
     getVar(name: string) {
         return this.variables.get(name);
+    }
+
+    getUniqueTag(name: string) {
+        return `${name}.${this.tagCounter++}`;
     }
 
 }


### PR DESCRIPTION
If the first term of an `and` operation results false, the second one is not evaluated.

Same if the first term return true in an `or` operation

Fixes #102 