### PR TITLE
[Pascal] Change function type keywords

### DIFF
--- a/gramaticas/karelpascal.jison
+++ b/gramaticas/karelpascal.jison
@@ -22,14 +22,10 @@
 "define-prototipo-instrucción"              { return 'PROTO'; }
 "define-prototipo-calculo"                   { return 'PROTO_INT'; }
 "define-prototipo-cálculo"                   { return 'PROTO_INT'; }
-"define-instrucción-entera"                 { return 'DEF_INT'; }
-"define-instruccion-entera"                 { return 'DEF_INT'; }
 "define-calculo"                            { return 'DEF_INT'; }
 "define-cálculo"                            { return 'DEF_INT'; }
 "define-prototipo-condicion"                 { return 'PROTO_BOOL'; }
 "define-prototipo-condición"                 { return 'PROTO_BOOL'; }
-"define-instrucción-booleana"               { return 'DEF_BOOL'; }
-"define-instruccion-booleana"               { return 'DEF_BOOL'; }
 "define-condicion"                          { return 'DEF_BOOL'; }
 "define-condición"                          { return 'DEF_BOOL'; }
 "sal-de-instruccion"                        { return 'RET'; }

--- a/gramaticas/karelpascal.jison
+++ b/gramaticas/karelpascal.jison
@@ -23,6 +23,8 @@
 "define-prototipo-entero"                   { return 'PROTO_INT'; }
 "define-instrucción-entera"                 { return 'DEF_INT'; }
 "define-instruccion-entera"                 { return 'DEF_INT'; }
+"define-calculo"                            { return 'DEF_INT'; }
+"define-cálculo"                            { return 'DEF_INT'; }
 "define-prototipo-booleano"                 { return 'PROTO_BOOL'; }
 "define-instrucción-booleana"               { return 'DEF_BOOL'; }
 "define-instruccion-booleana"               { return 'DEF_BOOL'; }

--- a/gramaticas/karelpascal.jison
+++ b/gramaticas/karelpascal.jison
@@ -20,12 +20,14 @@
 "usa"			                                  { return 'IMPORT'; }
 "define-prototipo-instruccion"              { return 'PROTO'; }
 "define-prototipo-instrucción"              { return 'PROTO'; }
-"define-prototipo-entero"                   { return 'PROTO_INT'; }
+"define-prototipo-calculo"                   { return 'PROTO_INT'; }
+"define-prototipo-cálculo"                   { return 'PROTO_INT'; }
 "define-instrucción-entera"                 { return 'DEF_INT'; }
 "define-instruccion-entera"                 { return 'DEF_INT'; }
 "define-calculo"                            { return 'DEF_INT'; }
 "define-cálculo"                            { return 'DEF_INT'; }
-"define-prototipo-booleano"                 { return 'PROTO_BOOL'; }
+"define-prototipo-condicion"                 { return 'PROTO_BOOL'; }
+"define-prototipo-condición"                 { return 'PROTO_BOOL'; }
 "define-instrucción-booleana"               { return 'DEF_BOOL'; }
 "define-instruccion-booleana"               { return 'DEF_BOOL'; }
 "define-condicion"                          { return 'DEF_BOOL'; }

--- a/src/__tests__/kp/ce/emptyReturn.kp
+++ b/src/__tests__/kp/ce/emptyReturn.kp
@@ -1,5 +1,5 @@
 iniciar-programa
-	define-instruccion-entera pasos como
+	define-calculo pasos como
 	inicio
 		avanza;
 	fin;

--- a/src/__tests__/kp/ce/halfFalseReturn.kp
+++ b/src/__tests__/kp/ce/halfFalseReturn.kp
@@ -1,5 +1,5 @@
 iniciar-programa
-	define-instruccion-entera pasos como
+	define-calculo pasos como
 	inicio
         si frente-libre entonces
         inicio

--- a/src/__tests__/kp/ce/halfTrueReturn.kp
+++ b/src/__tests__/kp/ce/halfTrueReturn.kp
@@ -1,5 +1,5 @@
 iniciar-programa
-	define-instruccion-entera pasos como
+	define-calculo pasos como
 	inicio
         si frente-libre entonces
         inicio

--- a/src/__tests__/kp/ce/prototypeType.kp
+++ b/src/__tests__/kp/ce/prototypeType.kp
@@ -1,7 +1,7 @@
 iniciar-programa
-	define-prototipo-booleano pasos;
+	define-prototipo-condicion pasos;
 
-	define-instruccion-entera pasos como
+	define-calculo pasos como
 	inicio
 		avanza;
 	fin;

--- a/src/__tests__/kp/ce/returnVoidToInt.kp
+++ b/src/__tests__/kp/ce/returnVoidToInt.kp
@@ -1,5 +1,5 @@
 iniciar-programa
-    define-instruccion-entera test(n) como
+    define-calculo test(n) como
     inicio
         regresa;
     fin;

--- a/src/__tests__/kp/ce/voidAsInt.kp
+++ b/src/__tests__/kp/ce/voidAsInt.kp
@@ -1,5 +1,5 @@
 iniciar-programa
-    define-instruccion-entera func como
+    define-calculo func como
     inicio
         regresa 4;
     fin;

--- a/src/__tests__/kp/ifReturn.kp
+++ b/src/__tests__/kp/ifReturn.kp
@@ -1,5 +1,5 @@
 iniciar-programa
-	define-instruccion-entera pasos como
+	define-calculo pasos como
 	inicio
         si frente-libre entonces
         inicio

--- a/src/__tests__/kp/intfunc.kp
+++ b/src/__tests__/kp/intfunc.kp
@@ -1,10 +1,10 @@
 iniciar-programa
-    define-instruccion-entera func como
+    define-calculo func como
     inicio
         regresa 5;
     fin;
 
-    define-instruccion-entera otro-func(n) como
+    define-calculo otro-func(n) como
     inicio
         si si-es-cero(n) entonces
         inicio

--- a/src/__tests__/kp/protoTypeTest.kp
+++ b/src/__tests__/kp/protoTypeTest.kp
@@ -1,9 +1,9 @@
 iniciar-programa
-	define-prototipo-entero numerico;
-	define-prototipo-booleano logico;
+	define-prototipo-calculo numerico;
+	define-prototipo-condicion logico;
 	define-prototipo-instruccion metodo;
 
-	define-instruccion-entera numerico como
+	define-calculo numerico como
 	inicio
 		avanza;
 		regresa 3;
@@ -14,7 +14,7 @@ iniciar-programa
 		avanza;
 	fin;
 
-	define-instruccion-booleana logico como
+	define-condicion logico como
 	inicio
 		avanza;
 		regresa orientado-al-norte;

--- a/src/__tests__/kp/shortCircuit.kp
+++ b/src/__tests__/kp/shortCircuit.kp
@@ -1,12 +1,12 @@
 usa rekarel.globales;
 iniciar-programa
-    define-instruccion-booleana always como 
+    define-condicion always como 
     inicio
         deja-zumbador;
         regresa verdadero;
     fin;
 
-    define-instruccion-booleana never como
+    define-condicion never como
     inicio
         deja-zumbador;
         deja-zumbador;

--- a/src/__tests__/problems/alfombraRoja/solution.kp
+++ b/src/__tests__/problems/alfombraRoja/solution.kp
@@ -1,7 +1,7 @@
 usa rekarel.globales;
 iniciar-programa
 
-	define-instruccion-entera dfs como
+	define-calculo dfs como
 	inicio
 		si frente-bloqueado y izquierda-bloqueada y derecha-bloqueada entonces
 		inicio

--- a/src/__tests__/problems/caminitoEscuela/solution.kp
+++ b/src/__tests__/problems/caminitoEscuela/solution.kp
@@ -10,7 +10,7 @@ iniciar-programa
 		turn(3);
 	fin;
 
-	define-instruccion-entera abs(n) como
+	define-calculo abs(n) como
 	inicio
 		si (0 <= n) entonces 
 			regresa n;


### PR DESCRIPTION
* `define-cálculo` for integer functions
* `define-condición`  for boolean functions
* Removed `define-instrucción-entera`
* Removed `define-instrucción-booleana`
* `define-prototipo-entero` renamed to `define-prototipo-cálculo` 
* `define-prototipo-booleano` renamed to `define-prototipo-condición` 
