### PR TITLE
[Refactor] Compiler always output the same structure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rekarel/core",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rekarel/core",
-      "version": "2.0.0-beta.5",
+      "version": "2.0.0-beta.14",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^26.0.1",

--- a/src/__tests__/java.test.ts
+++ b/src/__tests__/java.test.ts
@@ -32,7 +32,7 @@ describe("Java compilation tests ", ()=> {
     test("Test simple turnoff", ()=> {
         const turnoffJava = fs.readFileSync(__dirname +"/kj/turnoff.kj").toString();
         const result = compile (turnoffJava);
-        expect(result).toEqual([ [ 'LINE', 3, 2], [ 'HALT' ], [ 'LINE', 5, 0 ], [ 'HALT' ] ])
+        expect(result[0]).toEqual([ [ 'LINE', 3, 2], [ 'HALT' ], [ 'LINE', 5, 0 ], [ 'HALT' ] ])
         
     });
     test("Test that codes compile correctly", ()=> {
@@ -50,7 +50,7 @@ describe("Java compilation tests ", ()=> {
         expect(opcodes).toBeDefined()
         const world = new World(10, 10);
         world.setBagBuzzers(20);
-        runAll(world, opcodes! as RawProgram);
+        runAll(world, opcodes[0]);
         expect(world.buzzers(1, 1)).toBe(16);
         expect(world.bagBuzzers).toBe(4);
 
@@ -62,7 +62,7 @@ describe("Java compilation tests ", ()=> {
         expect(opcodes).toBeDefined()
         const world = new World(10, 10);
         world.setBagBuzzers(20);
-        runAll(world, opcodes! as RawProgram);
+        runAll(world, opcodes[0]);
         expect(world.buzzers(1, 1)).toBe(9);
         expect(world.bagBuzzers).toBe(11);
 
@@ -74,7 +74,7 @@ describe("Java compilation tests ", ()=> {
         expect(opcodes).toBeDefined()
         const world = new World(10, 10);
         world.setBagBuzzers(-1);
-        runAll(world, opcodes! as RawProgram);
+        runAll(world, opcodes[0]);
         expect(world.buzzers(1, 1)).toBe(5);
         expect(world.buzzers(10, 1)).toBe(40);
         expect(world.i).toBe(10); 
@@ -89,7 +89,7 @@ test("Test continue statement", () => {
     expect(opcodes).toBeDefined()
     const world = new World(10, 10);
     world.setBagBuzzers(-1);
-    runAll(world, opcodes! as RawProgram);
+    runAll(world, opcodes[0]);
     expect(world.buzzers(1, 1)).toBe(12);
     expect(world.orientation).toBe(1);    
 });
@@ -113,7 +113,7 @@ describe("Java globals test ", ()=> {
         world.setBuzzers(1, 1, 5);
         world.setBuzzers(3, 1, 2);
         world.setBagBuzzers(20);
-        runAll(world, opcodes! as RawProgram);
+        runAll(world, opcodes[0]);
         expect(world.buzzers(2, 1)).toBe(5);
         expect(world.buzzers(3, 1)).toBe(0);
         expect(world.bagBuzzers).toBe(17);
@@ -125,7 +125,7 @@ describe("Java globals test ", ()=> {
         expect(opcodes).toBeDefined()
         const world = new World(25,25);
         world.setBagBuzzers(12);
-        runAll(world, opcodes! as RawProgram);
+        runAll(world, opcodes[0]);
         expect(world.i).toBe(13);
         expect(world.j).toBe(1);
         expect(world.buzzers(13, 1)).toBe(12);
@@ -151,7 +151,7 @@ describe("Java globals test ", ()=> {
         const world = new World(25,25);
         world.setBagBuzzers(120);
         world.setBuzzers(1,1,10);
-        runAll(world, opcodes! as RawProgram);
+        runAll(world, opcodes[0]);
         expect(world.buzzers(1, 1)).toBe(14);
         expect(world.bagBuzzers).toBe(116);
     });
@@ -166,7 +166,7 @@ describe("Test Java functions", ()=>{
         expect(opcodes).toBeDefined()
         const world = new World(10, 10);
         world.setBagBuzzers(-1);
-        runAll(world, opcodes! as RawProgram);
+        runAll(world, opcodes[0]);
         expect(world.runtime.state.error).toBeUndefined();
         expect(world.buzzers(1, 1)).toBe(1);
         expect(world.buzzers(2, 1)).toBe(2);
@@ -180,7 +180,7 @@ test("Java short circuit", ()=> {
     expect(opcodes).toBeDefined()
     const world = new World(10, 10);
     world.setBagBuzzers(-1);
-    runAll(world, opcodes! as RawProgram);
+    runAll(world, opcodes[0]);
     expect(world.runtime.state.error).toBeUndefined();
     //Test and shorting
     expect(world.buzzers(1, 1)).toBe(6);

--- a/src/__tests__/pascal.test.ts
+++ b/src/__tests__/pascal.test.ts
@@ -37,7 +37,7 @@ describe("Pascal compilation tests ", () => {
     test("Test simple turnoff", () => {
         const source = fs.readFileSync(__dirname + "/kp/turnoff.kp").toString();
         const result = compile(source);
-        expect(result).toEqual([['LINE', 3, 2], ['HALT'], ['LINE', 5, 0], ['HALT']])
+        expect(result[0]).toEqual([['LINE', 3, 2], ['HALT'], ['LINE', 5, 0], ['HALT']])
 
     });
 
@@ -47,7 +47,7 @@ describe("Pascal compilation tests ", () => {
         expect(opcodes).toBeDefined()
         const world = new World(10, 10);
         world.setBagBuzzers(20);
-        runAll(world, opcodes! as RawProgram);
+        runAll(world, opcodes[0]);
         expect(world.buzzers(1, 1)).toBe(16);
         expect(world.bagBuzzers).toBe(4);
 
@@ -59,7 +59,7 @@ describe("Pascal compilation tests ", () => {
         expect(opcodes).toBeDefined()
         const world = new World(10, 10);
         world.setBagBuzzers(20);
-        runAll(world, opcodes! as RawProgram);
+        runAll(world, opcodes[0]);
         expect(world.buzzers(1, 1)).toBe(9);
         expect(world.bagBuzzers).toBe(11);
 
@@ -71,7 +71,7 @@ describe("Pascal compilation tests ", () => {
         expect(opcodes).toBeDefined()
         const world = new World(10, 10);
         world.setBagBuzzers(-1);
-        runAll(world, opcodes! as RawProgram);
+        runAll(world, opcodes[0]);
         expect(world.buzzers(1, 1)).toBe(5);
         expect(world.buzzers(10, 1)).toBe(40);
         expect(world.i).toBe(10); 
@@ -85,7 +85,7 @@ describe("Pascal compilation tests ", () => {
         expect(opcodes).toBeDefined()
         const world = new World(10, 10);
         world.setBagBuzzers(-1);
-        runAll(world, opcodes! as RawProgram);
+        runAll(world, opcodes[0]);
         expect(world.buzzers(1, 1)).toBe(12);
         expect(world.orientation).toBe(1);    
     });
@@ -122,7 +122,7 @@ describe("Pascal globals test ", () => {
         world.setBuzzers(1, 1, 5);
         world.setBuzzers(3, 1, 2);
         world.setBagBuzzers(20);
-        runAll(world, opcodes! as RawProgram);
+        runAll(world, opcodes[0]);
         expect(world.buzzers(2, 1)).toBe(5);
         expect(world.buzzers(3, 1)).toBe(0);
         expect(world.bagBuzzers).toBe(17);
@@ -134,7 +134,7 @@ describe("Pascal globals test ", () => {
         expect(opcodes).toBeDefined()
         const world = new World(25, 25);
         world.setBagBuzzers(12);
-        runAll(world, opcodes! as RawProgram);
+        runAll(world, opcodes[0]);
         expect(world.i).toBe(13);
         expect(world.j).toBe(1);
         expect(world.buzzers(13, 1)).toBe(12);
@@ -156,7 +156,7 @@ describe("Pascal globals test ", () => {
         const world = new World(25, 25);
         world.setBagBuzzers(120);
         world.setBuzzers(1, 1, 10);
-        runAll(world, opcodes! as RawProgram);
+        runAll(world, opcodes[0]);
         expect(world.buzzers(1, 1)).toBe(14);
         expect(world.bagBuzzers).toBe(116);
     });
@@ -169,7 +169,7 @@ describe("Test Pascal functions", ()=>{
         expect(opcodes).toBeDefined()
         const world = new World(10, 10);
         world.setBagBuzzers(-1);
-        runAll(world, opcodes! as RawProgram);
+        runAll(world, opcodes[0]);
         expect(world.runtime.state.error).toBeUndefined();
         expect(world.buzzers(1, 1)).toBe(1);
         expect(world.buzzers(2, 1)).toBe(2);
@@ -184,7 +184,7 @@ test("Pascal short circuit", ()=> {
     expect(opcodes).toBeDefined()
     const world = new World(10, 10);
     world.setBagBuzzers(-1);
-    runAll(world, opcodes! as RawProgram);
+    runAll(world, opcodes[0]);
     expect(world.runtime.state.error).toBeUndefined();
     //Test and shorting
     expect(world.buzzers(1, 1)).toBe(6);

--- a/src/compiler/InterRep/IRProcessor.ts
+++ b/src/compiler/InterRep/IRProcessor.ts
@@ -294,7 +294,7 @@ function resolveComplexIR(IRInstructions: IRInstruction[], yy: YY, definitions: 
     });
 }
 
-export function generateOpcodesFromIR(data: IRObject, exportDebug: boolean): RawProgram | [RawProgram, DebugData] {
+export function generateOpcodesFromIR(data: IRObject, exportDebug: boolean): [RawProgram, DebugData] {
     const definitions = new DefinitionTable(data.variablesCanBeFunctions);
     const debugData = new DebugData();
     // Step 1 - Populate global definitions, and check for repeated definitions
@@ -390,5 +390,5 @@ export function generateOpcodesFromIR(data: IRObject, exportDebug: boolean): Raw
         debugData.definitions = definitions;
         return [program, debugData];
     }
-    return program;
+    return [program, null];
 }

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -8,7 +8,7 @@ import { CompilationError } from './InterRep/compileErrors.js'
 
 export type Compiler = (
     ((code: string) => RawProgram ) 
-    | ( (code: string, exportDebug: boolean) => RawProgram | [RawProgram, DebugData])
+    | ( (code: string, exportDebug: boolean) => [RawProgram, DebugData])
 )
 
 type Parser = (code: string) => IRObject
@@ -57,7 +57,7 @@ export function detectLanguage(code: string): "java" | "pascal" | "unknown" {
 }
 
 
-export function compile(code:string, exportDebug: boolean = false) : RawProgram | [RawProgram, DebugData] | null {
+export function compile(code:string, exportDebug: boolean = false) : [RawProgram, DebugData] {
     let lang = detectLanguage(code);
     let compiler:Compiler = null;  
     switch (lang) {
@@ -86,12 +86,12 @@ export function compile(code:string, exportDebug: boolean = false) : RawProgram 
   
   
 
-export function javaCompiler(code:string, exportDebug: boolean = false): RawProgram | [RawProgram, DebugData] {
+export function javaCompiler(code:string, exportDebug: boolean = false):  [RawProgram, DebugData] {
     const IR = javaParser(code);
     return generateOpcodesFromIR(IR, exportDebug); 
 }
 
-export function pascalCompiler(code:string, exportDebug: boolean = false): RawProgram | [RawProgram, DebugData] {
+export function pascalCompiler(code:string, exportDebug: boolean = false): [RawProgram, DebugData] {
     const IR = pascalParser(code);
     return generateOpcodesFromIR(IR, exportDebug); 
 }


### PR DESCRIPTION
Now the compiler always outputs an array with [RawProgram | DebugData]. If the export debug data is set to false, then this second value is null