### PR TITLE
[Feature] AST uses parenthesis

### DIFF
--- a/gramaticas/kareljava.jison
+++ b/gramaticas/kareljava.jison
@@ -568,7 +568,15 @@ term
       };
     %}
   | '(' term ')'
-    { $$ = $term; }
+    { 
+      $$ = { 
+        term: $term
+        operation: "PARENTHESIS",
+        dataType: $term.dataType,
+        loc: $term.loc,
+        totalLoc: @$
+      };
+    }
   | clause
     { $$ = $1; }
   ;

--- a/gramaticas/karelpascal.jison
+++ b/gramaticas/karelpascal.jison
@@ -596,7 +596,15 @@ term
       };
       }
   | '(' term ')'
-    { $$ = $term; }
+    { 
+      $$ = { 
+        term: $term
+        operation: "PARENTHESIS",
+        dataType: $term.dataType,
+        loc: $term.loc,
+        totalLoc: @$
+      };
+    }
   | clause
     { $$ = $1; }
   ;

--- a/src/compiler/InterRep/AstExpression.ts
+++ b/src/compiler/InterRep/AstExpression.ts
@@ -149,7 +149,7 @@ function resolveTerm(tree: IRTerm, definitions: DefinitionTable, scope:Scope, ta
         target.push([tree.operation]);
         return tree.dataType;
     }
-    if (tree.operation === "PASS") {
+    if (tree.operation === "PASS" || tree.operation === "PARENTHESIS") {
         const termType = resolveTerm(tree.term, definitions, scope, target, tags, yy);
         if (termType !== tree.dataType) {
             yy.parser.parseError(`Expected a term of type ${tree.dataType}, but got ${termType}`, {

--- a/src/compiler/InterRep/IRInstruction.ts
+++ b/src/compiler/InterRep/IRInstruction.ts
@@ -79,6 +79,13 @@ export type IRTerm =
         loc: YYLoc,
         totalLoc: YYLoc,
     }
+    | {
+        operation: "PARENTHESIS",
+        term: IRTerm,
+        dataType: string,
+        loc: YYLoc,
+        totalLoc: YYLoc,
+    }
 ;
 
 /**


### PR DESCRIPTION
In terms use a type called parenthesis, this is so compilers can parse expressions easily.

Fixes #127 