### PR TITLE
[IR][Bug] Parenthesis with var inside failed to compile

### DIFF
--- a/src/compiler/InterRep/AstExpression.ts
+++ b/src/compiler/InterRep/AstExpression.ts
@@ -149,7 +149,7 @@ function resolveTerm(tree: IRTerm, definitions: DefinitionTable, scope:Scope, ta
         target.push([tree.operation]);
         return tree.dataType;
     }
-    if (tree.operation === "PASS" || tree.operation === "PARENTHESIS") {
+    if (tree.operation === "PASS") {
         const termType = resolveTerm(tree.term, definitions, scope, target, tags, yy);
         if (termType !== tree.dataType) {
             yy.parser.parseError(`Expected a term of type ${tree.dataType}, but got ${termType}`, {
@@ -161,6 +161,11 @@ function resolveTerm(tree: IRTerm, definitions: DefinitionTable, scope:Scope, ta
             });
         }
         return tree.dataType;
+
+    }
+    if (tree.operation === "PARENTHESIS") {
+        const termType = resolveTerm(tree.term, definitions, scope, target, tags, yy);        
+        return termType;
 
     }
 


### PR DESCRIPTION
Expressions like `(mochila)` or `(beeperBag)` now compile once again

Fixes #142 