### PR TITLE
[Feature][UX][Bug] Improve return line markers

### DIFF
--- a/gramaticas/kareljava.jison
+++ b/gramaticas/kareljava.jison
@@ -221,7 +221,12 @@ def
         code: [
           locToIR(@2),
           ...$block,
-          ['RET', '__DEFAULT', @1],
+          ['RET', '__DEFAULT', {
+            first_line: @5.last_line,
+            first_column: @5.last_column-1,
+            last_line: @5.last_line,
+            last_column: @5.last_column
+          }],
         ],  
         params: [], 
         loc: @$, 
@@ -238,7 +243,12 @@ def
         
           locToIR(@2),
           ...$block,
-          ['RET', '__DEFAULT', @1]
+          ['RET', '__DEFAULT', {
+            first_line: @6.last_line,
+            first_column: @6.last_column-1,
+            last_line: @6.last_line,
+            last_column: @6.last_column
+          }],
       ];
       let params = [$5];
     	$$ = [{
@@ -328,8 +338,7 @@ return
           atomType:"IMPLICIT.0"
         },
         loc: @1
-      }],
-      locToIR(@1)
+      }]
     ]; }
   | RET 
     { $$ = [
@@ -341,13 +350,11 @@ return
           atomType:"IMPLICIT.0"
         },
         loc: @1
-      }],      
-      locToIR(@1)
+      }]
     ]; }
   | RET  term 
     
     { $$ = [
-      locToIR(@1),
       ['RET', {
         term: $term,
         loc: @1

--- a/gramaticas/karelpascal.jison
+++ b/gramaticas/karelpascal.jison
@@ -264,7 +264,12 @@ def
         code: [
           locToIR(@2),
           ...$expr,
-          ['RET', '__DEFAULT', @1]
+          ['RET', '__DEFAULT', {
+            first_line: @4.last_line,
+            first_column: @4.last_column,
+            last_line: @4.last_line,
+            last_column: @4.last_column,
+          }]
         ],
         params: [], 
         loc: @$,
@@ -284,7 +289,12 @@ def
         code: [
           locToIR(@2),
           ...$expr,
-          ['RET', '__DEFAULT', @1]
+          ['RET', '__DEFAULT', {
+            first_line: @7.last_line,
+            first_column: @7.last_column,
+            last_line: @7.last_line,
+            last_line: @7.last_column,
+          }]
         ],
         params: $paramList,
         loc: @$,        
@@ -383,8 +393,7 @@ return
           dataType:"VOID"
         },
         loc: @1
-      }],
-      locToIR(@1)
+      }]
     ]; }
   | RET term
     
@@ -392,8 +401,7 @@ return
       ['RET', {
         term: $term,
         loc: @1
-      }],
-      locToIR(@1)
+      }]
     ]; }
   ;
 

--- a/src/compiler/InterRep/AstExpression.ts
+++ b/src/compiler/InterRep/AstExpression.ts
@@ -303,6 +303,7 @@ function resolveReturn(data: IRRet, definitions: DefinitionTable, scope:Scope, t
         });
     }
     target.push(["SRET"]);
+    target.push(["LINE", data.loc.first_line - 1, data.loc.first_column])
     target.push(["RET", data]);
 
 
@@ -593,6 +594,11 @@ export function resolveListWithASTs(IRInstructions: IRInstruction[], definitions
                 //set SRET to 0
                 target.push(["LOAD",0])
                 target.push(["SRET"])
+                target.push([
+                    "LINE", 
+                    instruction[2].first_line - 1,
+                    instruction[2].first_column
+                ]);
                 target.push(instruction);
                 continue;
             }


### PR DESCRIPTION
* Now functions have a line marker at the end for implicit returns
* Now returns have their marker after the parameters

Fixes #114 