### PR TITLE
[Bug] Add column/columna row/fila transpile variables

### DIFF
--- a/src/__tests__/kj/allCode.kj
+++ b/src/__tests__/kj/allCode.kj
@@ -52,6 +52,8 @@ class program {
 		if (false) {}
 		if (beeperBag == 0) {}
 		if (floorBeepers == 0) {}
+		if (row == 0) {}
+		if (column == 0) {}
 		//Test all logical operator
 		if (true && true) {}
 		if (true || true) {}

--- a/src/__tests__/kp/allCode.kp
+++ b/src/__tests__/kp/allCode.kp
@@ -114,6 +114,12 @@ iniciar-programa
 		si zumbadores-del-piso == 0 entonces
 		inicio
 		fin;
+		si fila == 0 entonces
+		inicio
+		fin;
+		si columna == 0 entonces
+		inicio
+		fin;
 		si verdadero y verdadero entonces
 		inicio
 		fin;

--- a/src/__tests__/transpiler.test.ts
+++ b/src/__tests__/transpiler.test.ts
@@ -17,4 +17,33 @@ describe("Transpiler tests ", ()=> {
         expect(pascal_pascal).toBe(pascal_pascal_pascal);
         
     });
+    
 });
+
+describe("", ()=> {    
+    const codes:Record<string,[string,string]> = {
+        rowVar:["kp/simpleRow.kp", "kj/simpleRow.kj"],
+        columnVar:["kp/simpleColumn.kp", "kj/simpleColumn.kj"],
+        backpackVar:["kp/simpleBackpack.kp", "kj/simpleBackpack.kj"],
+        floorVar:["kp/simpleFloor.kp", "kj/simpleFloor.kj"],
+    }
+    for (const [caseName, sources] of Object.entries(codes)) {
+        const [pascalCode, javaCode] = sources;
+        test(`Test ${caseName}`, ()=> {
+            const allJava = fs.readFileSync(`${__dirname}/${javaCode}`).toString();
+            const allPascal = fs.readFileSync(`${__dirname}/${pascalCode}`).toString();
+
+            const java_java = transpileCode(allJava, "java");
+            const java_pascal = transpileCode(allJava, "pascal");
+
+            const pascal_java = transpileCode(allPascal, "java");
+            const pascal_pascal = transpileCode(allPascal, "pascal");
+
+            expect(java_java).toBe(pascal_java);
+            expect(java_pascal).toBe(pascal_pascal);
+        })
+        
+    }
+
+    
+})

--- a/src/transpiler/javaTranspiler.ts
+++ b/src/transpiler/javaTranspiler.ts
@@ -103,6 +103,12 @@ function translateVars(word: string, data: TranspilerData):string {
         if (word === "falso") {
             return "false";
         }
+        if (word === "fila") {
+            return "row";
+        }
+        if (word === "columna") {
+            return "column";
+        }
     }
     return word;
 }

--- a/src/transpiler/pascalTranspiler.ts
+++ b/src/transpiler/pascalTranspiler.ts
@@ -105,6 +105,12 @@ function translateVars(word: string, data: TranspilerData):string {
         if (word === "false") {
             return "falso";
         }
+        if (word === "row") {
+            return "fila";
+        }
+        if (word === "column") {
+            return "columna";
+        }
     }
     return word;
 }


### PR DESCRIPTION
Now this code

```pascal
usa rekarel.globales;
iniciar-programa

	inicia-ejecucion
		repetir columna veces
		inicio
			avanza;
		fin;
		repetir fila veces
		inicio
			avanza;
		fin;
		apagate;
	termina-ejecucion   
finalizar-programa
```

Correctly compiles to
```javascript
import rekarel.globals;
class program {

	program() {
		iterate (column) {
			move();
		}
		iterate (row) {
			move();
		}
		turnoff();
	}   

}
```

Fixes #158 
Helps with #140 