### PR TITLE
Kishtarn555/issue190

### DIFF
--- a/src/__tests__/java.test.ts
+++ b/src/__tests__/java.test.ts
@@ -81,6 +81,23 @@ describe("Java compilation tests ", ()=> {
         expect(world.j).toBe(1);
         
     });
+
+    test("Test iterate", () => {
+        const source = fs.readFileSync(__dirname + "/kj/repeat.kj").toString();
+        const opcodes = compile(source);
+        expect(opcodes).toBeDefined()
+        const world = new World(10, 10);
+        world.setBagBuzzers(20);
+        world.maxInstructions = 100;
+
+        runAll(world, opcodes[0]);
+        
+        expect(world.runtime.state.error).toBeUndefined();
+        expect(world.buzzers(1, 1)).toBe(5);
+        expect(world.buzzers(2, 1)).toBe(0);
+        expect(world.buzzers(3, 1)).toBe(0);
+        expect(world.bagBuzzers).toBe(15);
+    });
 });
 
 test("Test continue statement", () => {

--- a/src/__tests__/kj/repeat.kj
+++ b/src/__tests__/kj/repeat.kj
@@ -1,0 +1,18 @@
+import rekarel.globals;
+
+class program {
+    program() {
+        iterate(5) {
+            putbeeper();
+        }
+        move();
+        iterate(0) {
+            putbeeper();
+        }
+        move();
+        iterate(pred(0,5)) {
+            putbeeper();
+        }
+        turnoff();
+    }
+}

--- a/src/__tests__/kp/repeat.kp
+++ b/src/__tests__/kp/repeat.kp
@@ -1,0 +1,13 @@
+usa rekarel.globales;
+iniciar-programa
+    inicia-ejecucion
+        repetir 5 veces
+            deja-zumbador;
+        avanza;
+        repetir 0 veces
+            deja-zumbador;
+        avanza;
+        repetir precede(0, 5) veces
+            deja-zumbador;
+	termina-ejecucion
+finalizar-programa

--- a/src/__tests__/pascal.test.ts
+++ b/src/__tests__/pascal.test.ts
@@ -224,3 +224,22 @@ test("Pascal short circuit", ()=> {
     expect(world.buzzers(7, 1)).toBe(7);
     expect(world.buzzers(8, 1)).toBe(4);
 });
+
+
+
+test("Test repetir", () => {
+    const source = fs.readFileSync(__dirname + "/kj/repeat.kj").toString();
+    const opcodes = compile(source);
+    expect(opcodes).toBeDefined()
+    const world = new World(10, 10);
+    world.setBagBuzzers(20);
+    world.maxInstructions = 100;
+
+    runAll(world, opcodes[0]);
+    
+    expect(world.runtime.state.error).toBeUndefined();
+    expect(world.buzzers(1, 1)).toBe(5);
+    expect(world.buzzers(2, 1)).toBe(0);
+    expect(world.buzzers(3, 1)).toBe(0);
+    expect(world.bagBuzzers).toBe(15);
+});

--- a/src/compiler/InterRep/AstExpression.ts
+++ b/src/compiler/InterRep/AstExpression.ts
@@ -338,7 +338,7 @@ function resolveRepeat(data: IRRepeat, definitions: DefinitionTable, scope:Scope
             ['TAG', data.repeatTag],
             ['DUP'],
             ['LOAD', 0], 
-            ['EQ'], 
+            ['LTE'], 
             ['NOT'], 
             ['TJZ', data.endTag]
         ],


### PR DESCRIPTION
Iterate (0) and iterate(pred(0, 10)) now both repeat 0 times

iterate now checks `!(counter <= 0)` to continue

Fixes #190