### PR TITLE
[Bug] Fix unexpected behaviour with ininite beepers

### DIFF
--- a/src/__tests__/runtime.test.ts
+++ b/src/__tests__/runtime.test.ts
@@ -95,7 +95,7 @@ describe("Test runtime", () => {
         expect(runtime.state.error).toBeUndefined(); 
         runtime.next();
         expect(runtime.state.error).toBeUndefined(); 
-        expect(KarelNumbers.isInfinite(world.buzzers(1,1))).toBe(12);
+        expect(KarelNumbers.isInfinite(world.buzzers(1,1))).toBe(true);
         expect(world.bagBuzzers).toBe(2);
     })
 

--- a/src/__tests__/runtime.test.ts
+++ b/src/__tests__/runtime.test.ts
@@ -81,6 +81,24 @@ describe("Test runtime", () => {
         expect(KarelNumbers.isInfinite(world.bagBuzzers)).toBe(true);
     })
 
+    test("Test LEAVEBUZZER with infinite cell", ()=> {
+        const world = new World(10,10)
+        const runtime = new Runtime(world);
+        world.runtime = runtime;
+        world.setBuzzers(1,1,KarelNumbers.a_infinite);
+        world.setBagBuzzers(4);
+        runtime.load([
+            ["LEAVEBUZZER"],
+            ["LEAVEBUZZER"],
+        ]);
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined(); 
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined(); 
+        expect(KarelNumbers.isInfinite(world.buzzers(1,1))).toBe(12);
+        expect(world.bagBuzzers).toBe(2);
+    })
+
     test("Test SRET", () => {
         const world = new World(10,10)
         const runtime = new Runtime(world);

--- a/src/__tests__/runtime.test.ts
+++ b/src/__tests__/runtime.test.ts
@@ -9,6 +9,78 @@ import { kareljava } from "../kareljava";
 
 describe("Test runtime", () => {
 
+    test("Test PICKBUZZER", ()=> {
+        const world = new World(10,10)
+        const runtime = new Runtime(world);
+        world.runtime = runtime;
+        world.setBuzzers(1,1,10);
+        runtime.load([
+            ["PICKBUZZER"],
+            ["PICKBUZZER"],
+        ]);
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined(); 
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined(); 
+        expect(world.buzzers(1,1)).toBe(8);
+        expect(world.bagBuzzers).toBe(2);
+    })
+
+    test("Test PICKBUZZER with infinite BAG", ()=> {
+        const world = new World(10,10)
+        const runtime = new Runtime(world);
+        world.runtime = runtime;
+        world.setBuzzers(1,1,10);
+        world.setBagBuzzers(KarelNumbers.a_infinite);
+        runtime.load([
+            ["PICKBUZZER"],
+            ["PICKBUZZER"],
+        ]);
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined(); 
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined(); 
+        expect(world.buzzers(1,1)).toBe(8);
+        expect(KarelNumbers.isInfinite(world.bagBuzzers)).toBe(true);
+    })
+
+    
+    test("Test LEAVEBUZZER", ()=> {
+        const world = new World(10,10)
+        const runtime = new Runtime(world);
+        world.runtime = runtime;
+        world.setBuzzers(1,1,10);
+        world.setBagBuzzers(4);
+        runtime.load([
+            ["LEAVEBUZZER"],
+            ["LEAVEBUZZER"],
+        ]);
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined(); 
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined(); 
+        expect(world.buzzers(1,1)).toBe(12);
+        expect(world.bagBuzzers).toBe(2);
+    })
+
+    test("Test LEAVEBUZZER with infinite BAG", ()=> {
+        const world = new World(10,10)
+        const runtime = new Runtime(world);
+        world.runtime = runtime;
+        world.setBuzzers(1,1,10);
+        world.setBagBuzzers(KarelNumbers.a_infinite);
+        runtime.load([
+            ["LEAVEBUZZER"],
+            ["LEAVEBUZZER"],
+        ]);
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined(); 
+        runtime.next();
+        expect(runtime.state.error).toBeUndefined(); 
+        expect(world.buzzers(1,1)).toBe(12);
+        expect(KarelNumbers.isInfinite(world.bagBuzzers)).toBe(true);
+    })
+
     test("Test SRET", () => {
         const world = new World(10,10)
         const runtime = new Runtime(world);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -247,7 +247,7 @@ export class Runtime {
     let rot;
     let di = [0, 1, 0, -1];
     let dj = [-1, 0, 1, 0];
-    let paramCount, newSP, op1, op2, fname, params, line, fromFName, npc;
+    let paramCount, newSP, op1, op2, fname, params, line, fromFName, npc, tmp;
     try {
       if (this.debug) {
         this.eventController.fireEvent('debug', this, {
@@ -421,8 +421,9 @@ export class Runtime {
 
         case OpCodeID.PICKBUZZER: {
           this.state.ic++;
-          if (!KarelNumbers.isInfinite(this.world.bagBuzzers)) {
-            this.world.pickBuzzer(this.world.i, this.world.j);
+          tmp = this.world.bagBuzzers
+          this.world.pickBuzzer(this.world.i, this.world.j);
+          if (!KarelNumbers.isInfinite(tmp)) {
             if (this.world.bagBuzzers > KarelNumbers.maximum) {
               this.state.running = false;
               this.state.error = ErrorType.BAGOVERFLOW;
@@ -446,8 +447,9 @@ export class Runtime {
 
         case OpCodeID.LEAVEBUZZER: {
           this.state.ic++;
-          if (!KarelNumbers.isInfinite(this.world.buzzers(this.world.i, this.world.j))) {
-            this.world.leaveBuzzer(this.world.i, this.world.j);
+          tmp = this.world.buzzers(this.world.i, this.world.j)
+          this.world.leaveBuzzer(this.world.i, this.world.j);
+          if (!KarelNumbers.isInfinite(tmp)) {
             if (this.world.buzzers(this.world.i, this.world.j) > KarelNumbers.maximum) {
               this.state.running = false;
               this.state.error = ErrorType.WORLDOVERFLOW;


### PR DESCRIPTION
While attempting to skip integer overflow on infinite amounts, the pickbeepers and leavebeeper were also skipped by accident