### PR TITLE
[Fix] Ignore out of bounds posicion dumps in files

### DIFF
--- a/src/world.ts
+++ b/src/world.ts
@@ -733,9 +733,14 @@ export class World {
             },
 
             posicionDump: function (dump) {
+                let i = parseInt(dump.getAttribute('y'), 10)
+                let j = parseInt(dump.getAttribute('x'), 10)
+                if (i <= 0 || j <=0 || i > self.h || j > self.w) {
+                    return;
+                }
                 self.dumpCells.push([
-                    parseInt(dump.getAttribute('y'), 10),
-                    parseInt(dump.getAttribute('x'), 10),
+                    i,
+                    j,
                 ]);
             },            
 


### PR DESCRIPTION
Some xml inputs have out of bounds posicionDump, which cause issues

As of now, they're no longer registered into the datastructure, but they still work as to not break retrocompatibility with old problems